### PR TITLE
DX-902: fix detect-non-ascii-char hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,43 +1,43 @@
 -   id: check-added-large-files
     name: check for added large files
     description: prevents giant files from being committed.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-added-large-files
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-added-large-files
     language: docker_image
     stages: [pre-commit, pre-push, manual]
     minimum_pre_commit_version: 3.2.0
 -   id: check-ast
     name: check python ast
     description: simply checks whether the files parse as valid python.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-ast
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-ast
     language: docker_image
     types: [python]
 -   id: check-byte-order-marker
     name: 'check BOM - deprecated: use fix-byte-order-marker'
     description: forbids files which have a utf-8 byte-order marker.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-byte-order-marker
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-byte-order-marker
     language: docker_image
     types: [text]
 -   id: check-builtin-literals
     name: check builtin type constructor use
     description: requires literal syntax when initializing empty or zero python builtin types.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-builtin-literals
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-builtin-literals
     language: docker_image
     types: [python]
 -   id: check-case-conflict
     name: check for case conflicts
     description: checks for files that would conflict in case-insensitive filesystems.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-case-conflict
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-case-conflict
     language: docker_image
 -   id: check-docstring-first
     name: check docstring is first
     description: checks a common error of defining a docstring after code.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-docstring-first
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-docstring-first
     language: docker_image
     types: [python]
 -   id: check-executables-have-shebangs
     name: check that executables have shebangs
     description: ensures that (non-binary) executables have a shebang.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-executables-have-shebangs
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-executables-have-shebangs
     language: docker_image
     types: [text, executable]
     stages: [pre-commit, pre-push, manual]
@@ -50,13 +50,13 @@
 -   id: check-json
     name: check json
     description: checks json files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-json
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-json
     language: docker_image
     types: [json]
 -   id: check-shebang-scripts-are-executable
     name: check that scripts with shebangs are executable
     description: ensures that (non-binary) files with a shebang are executable.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-shebang-scripts-are-executable
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-shebang-scripts-are-executable
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -64,80 +64,80 @@
 -   id: pretty-format-json
     name: pretty format json
     description: sets a standard for formatting json files.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 pretty-format-json
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 pretty-format-json
     language: docker_image
     types: [json]
 -   id: check-merge-conflict
     name: check for merge conflicts
     description: checks for files that contain merge conflict strings.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-merge-conflict
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-merge-conflict
     language: docker_image
     types: [text]
 -   id: check-symlinks
     name: check for broken symlinks
     description: checks for symlinks which do not point to anything.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-symlinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-symlinks
     language: docker_image
     types: [symlink]
 -   id: check-toml
     name: check toml
     description: checks toml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-toml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-toml
     language: docker_image
     types: [toml]
 -   id: check-vcs-permalinks
     name: check vcs permalinks
     description: ensures that links to vcs websites are permalinks.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-vcs-permalinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-vcs-permalinks
     language: docker_image
     types: [text]
 -   id: check-xml
     name: check xml
     description: checks xml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-xml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-xml
     language: docker_image
     types: [xml]
 -   id: check-yaml
     name: check yaml
     description: checks yaml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-yaml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-yaml
     language: docker_image
     types: [yaml]
 -   id: debug-statements
     name: debug statements (python)
     description: checks for debugger imports and py37+ `breakpoint()` calls in python source.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 debug-statement-hook
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 debug-statement-hook
     language: docker_image
     types: [python]
 -   id: destroyed-symlinks
     name: detect destroyed symlinks
     description: detects symlinks which are changed to regular files with a content of a path which that symlink was pointing to.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 destroyed-symlinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 destroyed-symlinks
     language: docker_image
     types: [file]
     stages: [pre-commit, pre-push, manual]
 -   id: detect-aws-credentials
     name: detect aws credentials
     description: detects *your* aws credentials from the aws cli credentials file.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-aws-credentials
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 detect-aws-credentials
     language: docker_image
     types: [text]
 -   id: detect-private-key
     name: detect private key
     description: detects the presence of private keys.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-private-key
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 detect-private-key
     language: docker_image
     types: [text]
 -   id: double-quote-string-fixer
     name: fix double quoted strings
     description: replaces double quoted strings with single quoted strings.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 string-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 string-fixer
     language: docker_image
     types: [python]
 -   id: end-of-file-fixer
     name: fix end of files
     description: ensures that a file is either empty, or ends with one newline.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 end-of-file-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 end-of-file-fixer
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -145,26 +145,26 @@
 -   id: file-contents-sorter
     name: file contents sorter
     description: sorts the lines in specified files (defaults to alphabetical). you must provide list of target files as input in your .pre-commit-config.yaml file.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 file-contents-sorter
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 file-contents-sorter
     language: docker_image
     files: '^$'
 -   id: fix-byte-order-marker
     name: fix utf-8 byte order marker
     description: removes utf-8 byte order marker.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 fix-byte-order-marker
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 fix-byte-order-marker
     language: docker_image
     types: [text]
 -   id: fix-encoding-pragma
     name: fix python encoding pragma (deprecated)
     description: 'adds # -*- coding: utf-8 -*- to the top of python files.'
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 fix-encoding-pragma
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 fix-encoding-pragma
     types: [python]
 -   id: forbid-new-submodules
     name: forbid new submodules
     description: prevents addition of new git submodules.
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 forbid-new-submodules
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 forbid-new-submodules
     types: [directory]
 -   id: forbid-submodules
     name: forbid submodules
@@ -175,37 +175,37 @@
 -   id: mixed-line-ending
     name: mixed line ending
     description: replaces or checks mixed line ending.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 mixed-line-ending
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 mixed-line-ending
     language: docker_image
     types: [text]
 -   id: name-tests-test
     name: python tests naming
     description: verifies that test files are named correctly.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 tests-should-end-in-test
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 tests-should-end-in-test
     language: docker_image
     files: (^|/)tests/.+\.py$
 -   id: no-commit-to-branch
     name: "don't commit to branch"
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 no-commit-to-branch
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 no-commit-to-branch
     language: docker_image
     pass_filenames: false
     always_run: true
 -   id: requirements-txt-fixer
     name: fix requirements.txt
     description: sorts entries in requirements.txt.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 requirements-txt-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 requirements-txt-fixer
     language: docker_image
     files: (requirements|constraints).*\.txt$
 -   id: sort-simple-yaml
     name: sort simple yaml files
     description: sorts simple yaml files which consist only of top-level keys, preserving comments and blocks.
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 sort-simple-yaml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 sort-simple-yaml
     files: '^$'
 -   id: trailing-whitespace
     name: trim trailing whitespace
     description: trims trailing whitespace.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 trailing-whitespace-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 trailing-whitespace-fixer
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -220,6 +220,5 @@
 -   id: detect-non-ascii-characters
     name: detect non-ascii characters
     description: detects non-ascii characters with support for multiple validation modes (balanced, visible-plus, ascii-only) and configurable byte ranges.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-non-ascii-characters
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 detect-non-ascii-characters
     language: docker_image
-    types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,43 +1,43 @@
 -   id: check-added-large-files
     name: check for added large files
     description: prevents giant files from being committed.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-added-large-files
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-added-large-files
     language: docker_image
     stages: [pre-commit, pre-push, manual]
     minimum_pre_commit_version: 3.2.0
 -   id: check-ast
     name: check python ast
     description: simply checks whether the files parse as valid python.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-ast
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-ast
     language: docker_image
     types: [python]
 -   id: check-byte-order-marker
     name: 'check BOM - deprecated: use fix-byte-order-marker'
     description: forbids files which have a utf-8 byte-order marker.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-byte-order-marker
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-byte-order-marker
     language: docker_image
     types: [text]
 -   id: check-builtin-literals
     name: check builtin type constructor use
     description: requires literal syntax when initializing empty or zero python builtin types.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-builtin-literals
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-builtin-literals
     language: docker_image
     types: [python]
 -   id: check-case-conflict
     name: check for case conflicts
     description: checks for files that would conflict in case-insensitive filesystems.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-case-conflict
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-case-conflict
     language: docker_image
 -   id: check-docstring-first
     name: check docstring is first
     description: checks a common error of defining a docstring after code.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-docstring-first
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-docstring-first
     language: docker_image
     types: [python]
 -   id: check-executables-have-shebangs
     name: check that executables have shebangs
     description: ensures that (non-binary) executables have a shebang.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-executables-have-shebangs
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-executables-have-shebangs
     language: docker_image
     types: [text, executable]
     stages: [pre-commit, pre-push, manual]
@@ -50,13 +50,13 @@
 -   id: check-json
     name: check json
     description: checks json files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-json
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-json
     language: docker_image
     types: [json]
 -   id: check-shebang-scripts-are-executable
     name: check that scripts with shebangs are executable
     description: ensures that (non-binary) files with a shebang are executable.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-shebang-scripts-are-executable
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-shebang-scripts-are-executable
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -64,80 +64,80 @@
 -   id: pretty-format-json
     name: pretty format json
     description: sets a standard for formatting json files.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 pretty-format-json
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 pretty-format-json
     language: docker_image
     types: [json]
 -   id: check-merge-conflict
     name: check for merge conflicts
     description: checks for files that contain merge conflict strings.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-merge-conflict
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-merge-conflict
     language: docker_image
     types: [text]
 -   id: check-symlinks
     name: check for broken symlinks
     description: checks for symlinks which do not point to anything.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-symlinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-symlinks
     language: docker_image
     types: [symlink]
 -   id: check-toml
     name: check toml
     description: checks toml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-toml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-toml
     language: docker_image
     types: [toml]
 -   id: check-vcs-permalinks
     name: check vcs permalinks
     description: ensures that links to vcs websites are permalinks.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-vcs-permalinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-vcs-permalinks
     language: docker_image
     types: [text]
 -   id: check-xml
     name: check xml
     description: checks xml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-xml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-xml
     language: docker_image
     types: [xml]
 -   id: check-yaml
     name: check yaml
     description: checks yaml files for parseable syntax.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 check-yaml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 check-yaml
     language: docker_image
     types: [yaml]
 -   id: debug-statements
     name: debug statements (python)
     description: checks for debugger imports and py37+ `breakpoint()` calls in python source.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 debug-statement-hook
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 debug-statement-hook
     language: docker_image
     types: [python]
 -   id: destroyed-symlinks
     name: detect destroyed symlinks
     description: detects symlinks which are changed to regular files with a content of a path which that symlink was pointing to.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 destroyed-symlinks
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 destroyed-symlinks
     language: docker_image
     types: [file]
     stages: [pre-commit, pre-push, manual]
 -   id: detect-aws-credentials
     name: detect aws credentials
     description: detects *your* aws credentials from the aws cli credentials file.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 detect-aws-credentials
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-aws-credentials
     language: docker_image
     types: [text]
 -   id: detect-private-key
     name: detect private key
     description: detects the presence of private keys.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 detect-private-key
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-private-key
     language: docker_image
     types: [text]
 -   id: double-quote-string-fixer
     name: fix double quoted strings
     description: replaces double quoted strings with single quoted strings.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 string-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 string-fixer
     language: docker_image
     types: [python]
 -   id: end-of-file-fixer
     name: fix end of files
     description: ensures that a file is either empty, or ends with one newline.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 end-of-file-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 end-of-file-fixer
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -145,26 +145,26 @@
 -   id: file-contents-sorter
     name: file contents sorter
     description: sorts the lines in specified files (defaults to alphabetical). you must provide list of target files as input in your .pre-commit-config.yaml file.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 file-contents-sorter
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 file-contents-sorter
     language: docker_image
     files: '^$'
 -   id: fix-byte-order-marker
     name: fix utf-8 byte order marker
     description: removes utf-8 byte order marker.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 fix-byte-order-marker
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 fix-byte-order-marker
     language: docker_image
     types: [text]
 -   id: fix-encoding-pragma
     name: fix python encoding pragma (deprecated)
     description: 'adds # -*- coding: utf-8 -*- to the top of python files.'
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 fix-encoding-pragma
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 fix-encoding-pragma
     types: [python]
 -   id: forbid-new-submodules
     name: forbid new submodules
     description: prevents addition of new git submodules.
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 forbid-new-submodules
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 forbid-new-submodules
     types: [directory]
 -   id: forbid-submodules
     name: forbid submodules
@@ -175,37 +175,37 @@
 -   id: mixed-line-ending
     name: mixed line ending
     description: replaces or checks mixed line ending.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 mixed-line-ending
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 mixed-line-ending
     language: docker_image
     types: [text]
 -   id: name-tests-test
     name: python tests naming
     description: verifies that test files are named correctly.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 tests-should-end-in-test
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 tests-should-end-in-test
     language: docker_image
     files: (^|/)tests/.+\.py$
 -   id: no-commit-to-branch
     name: "don't commit to branch"
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 no-commit-to-branch
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 no-commit-to-branch
     language: docker_image
     pass_filenames: false
     always_run: true
 -   id: requirements-txt-fixer
     name: fix requirements.txt
     description: sorts entries in requirements.txt.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 requirements-txt-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 requirements-txt-fixer
     language: docker_image
     files: (requirements|constraints).*\.txt$
 -   id: sort-simple-yaml
     name: sort simple yaml files
     description: sorts simple yaml files which consist only of top-level keys, preserving comments and blocks.
     language: docker_image
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 sort-simple-yaml
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 sort-simple-yaml
     files: '^$'
 -   id: trailing-whitespace
     name: trim trailing whitespace
     description: trims trailing whitespace.
-    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-2 trailing-whitespace-fixer
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 trailing-whitespace-fixer
     language: docker_image
     types: [text]
     stages: [pre-commit, pre-push, manual]
@@ -220,6 +220,6 @@
 -   id: detect-non-ascii-characters
     name: detect non-ascii characters
     description: detects non-ascii characters with support for multiple validation modes (balanced, visible-plus, ascii-only) and configurable byte ranges.
-    entry: detect-non-ascii-characters
-    language: python
+    entry: artifactory.adtran.com/docker/pre-commit-hooks:5.0.0-3 detect-non-ascii-characters
+    language: docker_image
     types: [text]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit_hooks
-version = 5.0.0.2
+version = 5.0.0.3
 description = Some out-of-the-box hooks for pre-commit.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit_hooks
-version = 5.0.0.3
+version = 5.0.0.2
 description = Some out-of-the-box hooks for pre-commit.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
The configuration was incorrect for the _detect-non-ascii-characters_ hook. 

Using the pre-commit filter to only check non-binary files can improve the performance of the hook.